### PR TITLE
Create Flask web app for medical forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+ssmo.db
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # SSMO
-trabajo
+
+Aplicación web para gestionar formularios médicos del Servicio de Salud Metropolitano Oriente (SSMO).
+
+## Características
+
+- Formulario web para ingresar los datos administrativos y clínicos del paciente.
+- Validaciones básicas (campos obligatorios y formato de RUT chileno).
+- Generación automática de una plantilla resumen para copiar y compartir.
+- Persistencia de los registros en una base de datos SQLite.
+- Listado de formularios guardados para consultar registros anteriores.
+
+## Requisitos
+
+- Python 3.11+
+- Dependencias listadas en `requirements.txt`
+
+## Instalación y ejecución
+
+1. Crear y activar un entorno virtual (opcional pero recomendado):
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # En Windows usar .venv\Scripts\activate
+   ```
+
+2. Instalar las dependencias:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Ejecutar la aplicación:
+
+   ```bash
+   flask --app app run --debug
+   ```
+
+4. Abrir el navegador en `http://127.0.0.1:5000/` para acceder al formulario.
+
+La base de datos `ssmo.db` se crea automáticamente la primera vez que se ejecuta la aplicación.
+
+## Desarrollo
+
+- Los estilos principales se encuentran en `static/styles.css`.
+- Las plantillas HTML viven en la carpeta `templates/`.
+- El modelo de datos y las rutas están definidas en `app.py`.
+
+Para ejecutar las pruebas manuales, puede completar el formulario y verificar que la plantilla generada contenga los datos ingresados y que el registro se encuentre disponible en el listado de formularios guardados.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from flask import Flask, flash, redirect, render_template, request, url_for
+from flask_sqlalchemy import SQLAlchemy
+
+BASE_DIR = Path(__file__).resolve().parent
+DATABASE_PATH = BASE_DIR / "ssmo.db"
+
+app = Flask(__name__)
+app.config.update(
+    SECRET_KEY="cambio-esto-en-produccion",
+    SQLALCHEMY_DATABASE_URI=f"sqlite:///{DATABASE_PATH}",
+    SQLALCHEMY_TRACK_MODIFICATIONS=False,
+)
+
+db = SQLAlchemy(app)
+
+
+@dataclass
+class MedicalForm(db.Model):
+    """Modelo que representa un formulario médico almacenado."""
+
+    __tablename__ = "medical_forms"
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    servicio_salud: str = db.Column(db.String(120), nullable=False, default="Metropolitano Oriente")
+    establecimiento: str = db.Column(db.String(120))
+    especialidad: str = db.Column(db.String(120))
+    unidad: str = db.Column(db.String(120))
+    nombre: str = db.Column(db.String(160), nullable=False)
+    historia_clinica: str = db.Column(db.String(120))
+    rut: str = db.Column(db.String(20))
+    rut_padre: str = db.Column(db.String(20))
+    sexo: str = db.Column(db.String(20))
+    fecha_nacimiento: str = db.Column(db.String(20))
+    edad: str = db.Column(db.String(20))
+    domicilio: str = db.Column(db.String(160))
+    comuna: str = db.Column(db.String(80))
+    telefono1: str = db.Column(db.String(40))
+    telefono2: str = db.Column(db.String(40))
+    correo1: str = db.Column(db.String(120))
+    correo2: str = db.Column(db.String(120))
+    establecimiento_derivacion: str = db.Column(db.String(160))
+    grupo_poblacional: str = db.Column(db.String(40))
+    tipo_consulta: str = db.Column(db.String(40))
+    tiene_terapias: str = db.Column(db.String(10))
+    terapias_otro: str = db.Column(db.Text)
+    hipotesis_diagnostico: str = db.Column(db.Text)
+    es_ges: str = db.Column(db.String(10))
+    fundamento_diagnostico: str = db.Column(db.Text)
+    examenes_realizados: str = db.Column(db.Text)
+    nombre_medico: str = db.Column(db.String(160))
+    rut_medico: str = db.Column(db.String(20))
+    patologias_ges: str = db.Column(db.Text)
+
+    def patologias_ges_lista(self) -> List[str]:
+        if not self.patologias_ges:
+            return []
+        return [item.strip() for item in self.patologias_ges.split(";") if item.strip()]
+
+    def resumen_texto(self) -> str:
+        """Genera un texto de resumen con los datos del formulario."""
+
+        patologias = ", ".join(self.patologias_ges_lista()) or "Sin patologías GES registradas"
+        return (
+            "FORMULARIO GUARDADO\n"
+            "===================\n\n"
+            f"Fecha de registro: {self.created_at.strftime('%d/%m/%Y %H:%M')}\n\n"
+            "DATOS PERSONALES\n"
+            f"• Nombre: {self.nombre or 'No especificado'}\n"
+            f"• RUT: {self.rut or 'No especificado'}\n"
+            f"• Fecha de nacimiento: {self.fecha_nacimiento or 'No especificada'}\n"
+            f"• Edad: {self.edad or 'No especificada'}\n"
+            f"• Comuna: {self.comuna or 'No especificada'}\n\n"
+            "DATOS MÉDICOS\n"
+            f"• Especialidad: {self.especialidad or 'No especificada'}\n"
+            f"• Tipo de consulta: {self.tipo_consulta or 'No especificado'}\n"
+            f"• Hipótesis diagnóstica: {self.hipotesis_diagnostico or 'No especificada'}\n"
+            f"• Exámenes realizados: {self.examenes_realizados or 'No especificados'}\n"
+            f"• Médico responsable: {self.nombre_medico or 'No especificado'}\n\n"
+            "GES\n"
+            f"• Caso GES: {self.es_ges or 'No especificado'}\n"
+            f"• Patologías declaradas: {patologias}\n"
+        )
+
+
+FORM_FIELDS: List[str] = [
+    "servicio_salud",
+    "establecimiento",
+    "especialidad",
+    "unidad",
+    "nombre",
+    "historia_clinica",
+    "rut",
+    "rut_padre",
+    "sexo",
+    "fecha_nacimiento",
+    "edad",
+    "domicilio",
+    "comuna",
+    "telefono1",
+    "telefono2",
+    "correo1",
+    "correo2",
+    "establecimiento_derivacion",
+    "grupo_poblacional",
+    "tipo_consulta",
+    "tiene_terapias",
+    "terapias_otro",
+    "hipotesis_diagnostico",
+    "es_ges",
+    "fundamento_diagnostico",
+    "examenes_realizados",
+    "nombre_medico",
+    "rut_medico",
+]
+
+PATOLOGIAS_GES: List[str] = [
+    "Trastorno depresivo mayor",
+    "Esquizofrenia",
+    "Consumo perjudicial de alcohol y drogas",
+    "Trastorno de ansiedad",
+    "Trastorno del espectro autista",
+]
+
+
+def _extraer_datos_formulario(form_data) -> Dict[str, Optional[str]]:
+    datos = {campo: form_data.get(campo) or "" for campo in FORM_FIELDS}
+    patologias = form_data.getlist("patologias_ges")
+    datos["patologias_ges"] = ";".join(patologias)
+    return datos
+
+
+def _validar_datos(datos: Dict[str, str]) -> List[str]:
+    errores: List[str] = []
+    if not datos["nombre"].strip():
+        errores.append("El nombre del paciente es obligatorio.")
+    if not datos["servicio_salud"].strip():
+        errores.append("Debe indicar el servicio de salud.")
+
+    for rut_field in ("rut", "rut_padre", "rut_medico"):
+        rut = datos.get(rut_field, "").strip()
+        if rut and not _rut_valido(rut):
+            errores.append(f"El RUT ingresado en '{rut_field}' no es válido.")
+    return errores
+
+
+def _rut_valido(rut: str) -> bool:
+    """Valida RUT chileno considerando dígito verificador."""
+
+    rut = rut.replace(".", "").replace("-", "").upper()
+    if not rut[:-1].isdigit() or len(rut) < 8:
+        return False
+    cuerpo = rut[:-1]
+    dv = rut[-1]
+
+    suma = 0
+    factor = 2
+    for digito in reversed(cuerpo):
+        suma += int(digito) * factor
+        factor = 2 if factor == 7 else factor + 1
+    resto = suma % 11
+    digito_esperado = "0" if resto == 0 else "K" if resto == 1 else str(11 - resto)
+    return dv == digito_esperado
+
+
+@app.route("/", methods=["GET", "POST"])
+def formulario():
+    if request.method == "POST":
+        datos = _extraer_datos_formulario(request.form)
+        errores = _validar_datos(datos)
+
+        if errores:
+            for error in errores:
+                flash(error, "error")
+            return render_template(
+                "form.html",
+                campos=datos,
+                patologias=PATOLOGIAS_GES,
+                errores=errores,
+            )
+
+        registro = MedicalForm(**datos)
+        db.session.add(registro)
+        db.session.commit()
+        flash("Formulario guardado correctamente.", "success")
+        return redirect(url_for("ver_formulario", form_id=registro.id))
+
+    valores_iniciales = {campo: "" for campo in FORM_FIELDS}
+    valores_iniciales["servicio_salud"] = "Metropolitano Oriente"
+    return render_template(
+        "form.html",
+        campos=valores_iniciales,
+        patologias=PATOLOGIAS_GES,
+        errores=[],
+    )
+
+
+@app.route("/formularios")
+def listar_formularios():
+    registros = MedicalForm.query.order_by(MedicalForm.created_at.desc()).all()
+    return render_template("entries.html", registros=registros)
+
+
+@app.route("/formularios/<int:form_id>")
+def ver_formulario(form_id: int):
+    registro: Optional[MedicalForm] = MedicalForm.query.get_or_404(form_id)
+    return render_template("summary.html", registro=registro)
+
+
+@app.context_processor
+def inject_globals():
+    return {"patologias_catalogo": PATOLOGIAS_GES}
+
+
+@app.before_first_request
+def inicializar_db():
+    db.create_all()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# Requerimientos para el formulario médico SSMO
-tkinter  # Biblioteca GUI que viene incluida con Python
+Flask==3.0.3
+Flask-SQLAlchemy==3.1.1

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,325 @@
+:root {
+  color-scheme: light;
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  --primary: #276ef1;
+  --secondary: #f2f4f7;
+  --border: #d0d7de;
+  --text: #111827;
+  --muted: #6b7280;
+  --error: #b42318;
+  --success: #027a48;
+}
+
+body {
+  background: #f9fafb;
+  color: var(--text);
+  margin: 0;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.app-header,
+.app-footer {
+  background: white;
+  border-bottom: 1px solid var(--border);
+}
+
+.app-header {
+  padding: 1.5rem 0;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.app-header nav {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.app-header a,
+.app-footer a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.app-footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  padding: 1.5rem 0;
+  margin-top: 3rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+main {
+  margin-top: 2rem;
+}
+
+h2 {
+  margin-bottom: 0.5rem;
+}
+
+.section-description {
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.formulario section {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.formulario h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.field-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.field-grid label,
+.checkbox-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.field-grid label span {
+  font-weight: 600;
+}
+
+.field-grid input,
+.field-grid select,
+.field-grid textarea,
+.summary-text,
+.checkbox-item input {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.field-grid textarea {
+  resize: vertical;
+}
+
+.field-grid label.wide {
+  grid-column: 1 / -1;
+}
+
+.checkbox-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.checkbox-item {
+  align-items: center;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.checkbox-item span {
+  font-weight: 500;
+}
+
+.checkbox-item input {
+  width: 18px;
+  height: 18px;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+button.primary,
+a.primary,
+a.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+button.primary,
+a.primary {
+  background: var(--primary);
+  color: white;
+}
+
+a.secondary {
+  background: var(--secondary);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+button.primary:hover,
+a.primary:hover {
+  background: #1745a3;
+}
+
+a.secondary:hover {
+  background: #e5e7eb;
+}
+
+.flash-messages {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.flash-message {
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  border: 1px solid transparent;
+}
+
+.flash-success {
+  border-color: rgba(2, 122, 72, 0.25);
+  background: rgba(209, 250, 229, 0.6);
+  color: var(--success);
+}
+
+.flash-error {
+  border-color: rgba(180, 35, 24, 0.25);
+  background: rgba(254, 226, 226, 0.6);
+  color: var(--error);
+}
+
+.alert {
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border);
+  background: #fff4f3;
+  margin-bottom: 1.5rem;
+}
+
+.alert h3 {
+  margin-top: 0;
+}
+
+.summary {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+.summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.summary-section {
+  margin-bottom: 2rem;
+}
+
+.summary-section h3 {
+  margin-bottom: 1rem;
+}
+
+.summary-section dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem 1rem;
+  margin: 0;
+}
+
+.summary-section dt {
+  font-weight: 600;
+}
+
+.summary-section dd {
+  margin: 0.15rem 0 0;
+  color: var(--muted);
+}
+
+.summary-section ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.summary-text {
+  width: 100%;
+  background: #f3f4f6;
+}
+
+.entries {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.entries-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.entries-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.entries-table th,
+.entries-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.entries-table th {
+  background: #f3f4f6;
+}
+
+.empty-state {
+  color: var(--muted);
+  text-align: center;
+  margin: 2rem 0;
+}
+
+@media (max-width: 640px) {
+  .summary-header,
+  .entries-header,
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}SSMO - Formulario Médico{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha512-NhSC1YmyruXifcj/KFRWoC561YpHpc5JtzgvM9q4CPY/c/pXHi1S3FoZP4GkJcSdOkZ2z8I1w4qIu9hKkR3oyg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="container">
+        <h1>Servicio de Salud Metropolitano Oriente</h1>
+        <nav>
+          <a href="{{ url_for('formulario') }}">Nuevo formulario</a>
+          <a href="{{ url_for('listar_formularios') }}">Formularios guardados</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <ul class="flash-messages">
+            {% for category, message in messages %}
+              <li class="flash-message flash-{{ category }}">{{ message }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
+
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="app-footer">
+      <div class="container">
+        <p>SSMO · Gestión de formularios médicos</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+
+{% block title %}Formularios guardados · SSMO{% endblock %}
+
+{% block content %}
+  <section class="entries">
+    <header class="entries-header">
+      <div>
+        <h2>Formularios guardados</h2>
+        <p>Listado de registros almacenados en la base de datos.</p>
+      </div>
+      <a class="primary" href="{{ url_for('formulario') }}">Nuevo formulario</a>
+    </header>
+
+    {% if registros %}
+      <table class="entries-table">
+        <thead>
+          <tr>
+            <th>Fecha</th>
+            <th>Paciente</th>
+            <th>RUT</th>
+            <th>Especialidad</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for registro in registros %}
+            <tr>
+              <td>{{ registro.created_at.strftime('%d/%m/%Y %H:%M') }}</td>
+              <td>{{ registro.nombre }}</td>
+              <td>{{ registro.rut or '—' }}</td>
+              <td>{{ registro.especialidad or '—' }}</td>
+              <td>
+                <a class="secondary" href="{{ url_for('ver_formulario', form_id=registro.id) }}">Ver plantilla</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="empty-state">Todavía no hay registros guardados. Cree uno nuevo para comenzar.</p>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,193 @@
+{% extends 'base.html' %}
+
+{% block title %}Nuevo formulario · SSMO{% endblock %}
+
+{% block content %}
+  <h2>Ingreso de datos médicos</h2>
+  <p class="section-description">
+    Complete el formulario con la información requerida. Al guardar, se generará una plantilla con los datos ingresados y el registro quedará almacenado en la base de datos.
+  </p>
+
+  {% if errores %}
+    <div class="alert alert-error">
+      <h3>Revise los siguientes campos:</h3>
+      <ul>
+        {% for error in errores %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <form method="post" class="formulario">
+    <section>
+      <h3>Datos personales</h3>
+      <div class="field-grid">
+        <label>
+          <span>Servicio de salud *</span>
+          <input type="text" name="servicio_salud" value="{{ campos.servicio_salud }}" required />
+        </label>
+        <label>
+          <span>Establecimiento</span>
+          <input type="text" name="establecimiento" value="{{ campos.establecimiento }}" />
+        </label>
+        <label>
+          <span>Especialidad</span>
+          <input type="text" name="especialidad" value="{{ campos.especialidad }}" />
+        </label>
+        <label>
+          <span>Unidad</span>
+          <input type="text" name="unidad" value="{{ campos.unidad }}" />
+        </label>
+        <label>
+          <span>Nombre completo *</span>
+          <input type="text" name="nombre" value="{{ campos.nombre }}" required />
+        </label>
+        <label>
+          <span>Historia clínica</span>
+          <input type="text" name="historia_clinica" value="{{ campos.historia_clinica }}" />
+        </label>
+        <label>
+          <span>RUT paciente</span>
+          <input type="text" name="rut" value="{{ campos.rut }}" placeholder="11111111-1" />
+        </label>
+        <label>
+          <span>RUT apoderado</span>
+          <input type="text" name="rut_padre" value="{{ campos.rut_padre }}" placeholder="22222222-2" />
+        </label>
+        <label>
+          <span>Sexo</span>
+          <select name="sexo">
+            <option value="" {% if not campos.sexo %}selected{% endif %}></option>
+            <option value="Femenino" {% if campos.sexo == 'Femenino' %}selected{% endif %}>Femenino</option>
+            <option value="Masculino" {% if campos.sexo == 'Masculino' %}selected{% endif %}>Masculino</option>
+            <option value="Otro" {% if campos.sexo == 'Otro' %}selected{% endif %}>Otro</option>
+          </select>
+        </label>
+        <label>
+          <span>Fecha de nacimiento</span>
+          <input type="date" name="fecha_nacimiento" value="{{ campos.fecha_nacimiento }}" />
+        </label>
+        <label>
+          <span>Edad</span>
+          <input type="number" min="0" name="edad" value="{{ campos.edad }}" />
+        </label>
+        <label>
+          <span>Domicilio</span>
+          <input type="text" name="domicilio" value="{{ campos.domicilio }}" />
+        </label>
+        <label>
+          <span>Comuna</span>
+          <input type="text" name="comuna" value="{{ campos.comuna }}" />
+        </label>
+        <label>
+          <span>Teléfono 1</span>
+          <input type="tel" name="telefono1" value="{{ campos.telefono1 }}" />
+        </label>
+        <label>
+          <span>Teléfono 2</span>
+          <input type="tel" name="telefono2" value="{{ campos.telefono2 }}" />
+        </label>
+        <label>
+          <span>Correo electrónico 1</span>
+          <input type="email" name="correo1" value="{{ campos.correo1 }}" />
+        </label>
+        <label>
+          <span>Correo electrónico 2</span>
+          <input type="email" name="correo2" value="{{ campos.correo2 }}" />
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h3>Datos médicos</h3>
+      <div class="field-grid">
+        <label>
+          <span>Establecimiento de derivación</span>
+          <input type="text" name="establecimiento_derivacion" value="{{ campos.establecimiento_derivacion }}" />
+        </label>
+        <label>
+          <span>Grupo poblacional específico</span>
+          <select name="grupo_poblacional">
+            <option value="" {% if not campos.grupo_poblacional %}selected{% endif %}></option>
+            <option value="Sí" {% if campos.grupo_poblacional == 'Sí' %}selected{% endif %}>Sí</option>
+            <option value="No" {% if campos.grupo_poblacional == 'No' %}selected{% endif %}>No</option>
+          </select>
+        </label>
+        <label>
+          <span>Tipo de consulta</span>
+          <select name="tipo_consulta">
+            <option value="" {% if not campos.tipo_consulta %}selected{% endif %}></option>
+            <option value="Individual" {% if campos.tipo_consulta == 'Individual' %}selected{% endif %}>Individual</option>
+            <option value="Grupal" {% if campos.tipo_consulta == 'Grupal' %}selected{% endif %}>Grupal</option>
+          </select>
+        </label>
+        <label>
+          <span>¿Requiere terapias específicas?</span>
+          <select name="tiene_terapias">
+            <option value="" {% if not campos.tiene_terapias %}selected{% endif %}></option>
+            <option value="Sí" {% if campos.tiene_terapias == 'Sí' %}selected{% endif %}>Sí</option>
+            <option value="No" {% if campos.tiene_terapias == 'No' %}selected{% endif %}>No</option>
+          </select>
+        </label>
+        <label class="wide">
+          <span>Detalle terapias</span>
+          <textarea name="terapias_otro" rows="3">{{ campos.terapias_otro }}</textarea>
+        </label>
+        <label class="wide">
+          <span>Hipótesis diagnóstica</span>
+          <textarea name="hipotesis_diagnostico" rows="3">{{ campos.hipotesis_diagnostico }}</textarea>
+        </label>
+        <label>
+          <span>¿Caso GES?</span>
+          <select name="es_ges">
+            <option value="" {% if not campos.es_ges %}selected{% endif %}></option>
+            <option value="Sí" {% if campos.es_ges == 'Sí' %}selected{% endif %}>Sí</option>
+            <option value="No" {% if campos.es_ges == 'No' %}selected{% endif %}>No</option>
+          </select>
+        </label>
+        <label class="wide">
+          <span>Fundamento diagnóstico</span>
+          <textarea name="fundamento_diagnostico" rows="3">{{ campos.fundamento_diagnostico }}</textarea>
+        </label>
+        <label class="wide">
+          <span>Exámenes realizados</span>
+          <textarea name="examenes_realizados" rows="3">{{ campos.examenes_realizados }}</textarea>
+        </label>
+      </div>
+    </section>
+
+    <section>
+      <h3>Patologías GES</h3>
+      <p class="section-description">Seleccione todas las patologías que apliquen.</p>
+      <div class="checkbox-grid">
+        {% set seleccionadas = campos.patologias_ges.split(';') if campos.patologias_ges else [] %}
+        {% for patologia in patologias %}
+          <label class="checkbox-item">
+            <input type="checkbox" name="patologias_ges" value="{{ patologia }}" {% if patologia in seleccionadas %}checked{% endif %} />
+            <span>{{ patologia }}</span>
+          </label>
+        {% endfor %}
+      </div>
+    </section>
+
+    <section>
+      <h3>Profesional responsable</h3>
+      <div class="field-grid">
+        <label>
+          <span>Nombre médico</span>
+          <input type="text" name="nombre_medico" value="{{ campos.nombre_medico }}" />
+        </label>
+        <label>
+          <span>RUT médico</span>
+          <input type="text" name="rut_medico" value="{{ campos.rut_medico }}" placeholder="33333333-3" />
+        </label>
+      </div>
+    </section>
+
+    <div class="actions">
+      <button type="submit" class="primary">Guardar formulario</button>
+      <a class="secondary" href="{{ url_for('listar_formularios') }}">Ver registros existentes</a>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,0 +1,77 @@
+{% extends 'base.html' %}
+
+{% block title %}Plantilla generada · SSMO{% endblock %}
+
+{% block content %}
+  <article class="summary">
+    <header class="summary-header">
+      <div>
+        <h2>Plantilla de registro</h2>
+        <p>Formulario registrado el {{ registro.created_at.strftime('%d/%m/%Y a las %H:%M') }}</p>
+      </div>
+      <a class="secondary" href="{{ url_for('listar_formularios') }}">Volver al listado</a>
+    </header>
+
+    <section class="summary-section">
+      <h3>Datos personales</h3>
+      <dl>
+        <div><dt>Servicio de salud</dt><dd>{{ registro.servicio_salud or '—' }}</dd></div>
+        <div><dt>Establecimiento</dt><dd>{{ registro.establecimiento or '—' }}</dd></div>
+        <div><dt>Especialidad</dt><dd>{{ registro.especialidad or '—' }}</dd></div>
+        <div><dt>Unidad</dt><dd>{{ registro.unidad or '—' }}</dd></div>
+        <div><dt>Nombre</dt><dd>{{ registro.nombre }}</dd></div>
+        <div><dt>Historia clínica</dt><dd>{{ registro.historia_clinica or '—' }}</dd></div>
+        <div><dt>RUT paciente</dt><dd>{{ registro.rut or '—' }}</dd></div>
+        <div><dt>RUT apoderado</dt><dd>{{ registro.rut_padre or '—' }}</dd></div>
+        <div><dt>Sexo</dt><dd>{{ registro.sexo or '—' }}</dd></div>
+        <div><dt>Fecha de nacimiento</dt><dd>{{ registro.fecha_nacimiento or '—' }}</dd></div>
+        <div><dt>Edad</dt><dd>{{ registro.edad or '—' }}</dd></div>
+        <div><dt>Domicilio</dt><dd>{{ registro.domicilio or '—' }}</dd></div>
+        <div><dt>Comuna</dt><dd>{{ registro.comuna or '—' }}</dd></div>
+        <div><dt>Teléfonos</dt><dd>{{ registro.telefono1 or '—' }}{% if registro.telefono2 %} / {{ registro.telefono2 }}{% endif %}</dd></div>
+        <div><dt>Correos</dt><dd>{{ registro.correo1 or '—' }}{% if registro.correo2 %} / {{ registro.correo2 }}{% endif %}</dd></div>
+      </dl>
+    </section>
+
+    <section class="summary-section">
+      <h3>Información médica</h3>
+      <dl>
+        <div><dt>Establecimiento derivación</dt><dd>{{ registro.establecimiento_derivacion or '—' }}</dd></div>
+        <div><dt>Grupo poblacional</dt><dd>{{ registro.grupo_poblacional or '—' }}</dd></div>
+        <div><dt>Tipo de consulta</dt><dd>{{ registro.tipo_consulta or '—' }}</dd></div>
+        <div><dt>Terapias específicas</dt><dd>{{ registro.tiene_terapias or '—' }}</dd></div>
+        <div><dt>Detalle terapias</dt><dd>{{ registro.terapias_otro or '—' }}</dd></div>
+        <div><dt>Hipótesis diagnóstica</dt><dd>{{ registro.hipotesis_diagnostico or '—' }}</dd></div>
+        <div><dt>¿Caso GES?</dt><dd>{{ registro.es_ges or '—' }}</dd></div>
+        <div><dt>Fundamento diagnóstico</dt><dd>{{ registro.fundamento_diagnostico or '—' }}</dd></div>
+        <div><dt>Exámenes realizados</dt><dd>{{ registro.examenes_realizados or '—' }}</dd></div>
+        <div><dt>Patologías GES</dt>
+          <dd>
+            {% if registro.patologias_ges_lista() %}
+              <ul>
+                {% for patologia in registro.patologias_ges_lista() %}
+                  <li>{{ patologia }}</li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              Sin patologías registradas.
+            {% endif %}
+          </dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="summary-section">
+      <h3>Profesional responsable</h3>
+      <dl>
+        <div><dt>Nombre médico</dt><dd>{{ registro.nombre_medico or '—' }}</dd></div>
+        <div><dt>RUT médico</dt><dd>{{ registro.rut_medico or '—' }}</dd></div>
+      </dl>
+    </section>
+
+    <section class="summary-section">
+      <h3>Texto para copiar</h3>
+      <textarea readonly rows="12" class="summary-text">{{ registro.resumen_texto() }}</textarea>
+    </section>
+  </article>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace the previous desktop script with a Flask application for capturing SSMO medical form data
- persist submitted forms to SQLite and expose pages to create, list, and review saved entries
- add HTML templates and styles for the data entry form and generated summary, plus update documentation and requirements

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e65df756a4832ea114361656bb3bc0