### PR TITLE
Actualizar formulario con validaciones automáticas y remover PDF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask==3.0.3
 Flask-SQLAlchemy==3.1.1
-reportlab==4.2.2

--- a/static/form.js
+++ b/static/form.js
@@ -1,0 +1,162 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const fechaNacimientoInput = document.querySelector('input[name="fecha_nacimiento"]');
+  const edadInput = document.querySelector('input[name="edad"]');
+  const rutInputs = document.querySelectorAll('input[data-rut]');
+  const menorToggle = document.querySelector('#menor-edad');
+  const menorField = document.querySelector('[data-menor-field]');
+  const consultaSelector = document.querySelector('[data-consulta-selector]');
+  const consultaOtro = document.querySelector('[data-consulta-otro]');
+
+  const calcularEdad = (valor) => {
+    if (!valor || !edadInput) {
+      if (edadInput) {
+        edadInput.value = '';
+      }
+      return;
+    }
+    const partes = valor.split('-').map(Number);
+    if (partes.length !== 3 || partes.some(Number.isNaN)) {
+      edadInput.value = '';
+      return;
+    }
+    const [anio, mes, dia] = partes;
+    const nacimiento = new Date(Date.UTC(anio, mes - 1, dia));
+    if (Number.isNaN(nacimiento.getTime())) {
+      edadInput.value = '';
+      return;
+    }
+    const hoy = new Date();
+    let edad = hoy.getUTCFullYear() - nacimiento.getUTCFullYear();
+    const mesDiferencia = hoy.getUTCMonth() - nacimiento.getUTCMonth();
+    const diaDiferencia = hoy.getUTCDate() - nacimiento.getUTCDate();
+    if (mesDiferencia < 0 || (mesDiferencia === 0 && diaDiferencia < 0)) {
+      edad -= 1;
+    }
+    edadInput.value = edad >= 0 ? edad : '';
+  };
+
+  const limpiarRut = (valor) => valor.replace(/[^0-9Kk]/g, '');
+
+  const digitoVerificador = (cuerpo) => {
+    let suma = 0;
+    let factor = 2;
+    for (let i = cuerpo.length - 1; i >= 0; i -= 1) {
+      suma += parseInt(cuerpo[i], 10) * factor;
+      factor = factor === 7 ? 2 : factor + 1;
+    }
+    const resto = suma % 11;
+    if (resto === 0) return '0';
+    if (resto === 1) return 'K';
+    return String(11 - resto);
+  };
+
+  const normalizarRut = (valor) => {
+    const limpio = limpiarRut(valor).toUpperCase();
+    if (limpio.length < 2 || !/^[0-9]+$/.test(limpio.slice(0, -1))) {
+      return limpio;
+    }
+    const cuerpo = limpio.slice(0, -1);
+    let dv = limpio.slice(-1);
+    const esperado = digitoVerificador(cuerpo);
+    if (dv === '0' && esperado === 'K') {
+      dv = 'K';
+    }
+    return cuerpo + dv;
+  };
+
+  const formatearRut = (valor) => {
+    const normalizado = normalizarRut(valor);
+    if (normalizado.length < 2 || !/^[0-9]+$/.test(normalizado.slice(0, -1))) {
+      return normalizado;
+    }
+    const cuerpo = normalizado.slice(0, -1);
+    const dv = normalizado.slice(-1);
+    const reversed = cuerpo.split('').reverse();
+    const partes = [];
+    for (let i = 0; i < reversed.length; i += 1) {
+      partes.push(reversed[i]);
+      if ((i + 1) % 3 === 0 && i + 1 !== reversed.length) {
+        partes.push('.');
+      }
+    }
+    return `${partes.reverse().join('')}-${dv}`;
+  };
+
+  const rutValido = (valor) => {
+    const normalizado = normalizarRut(valor);
+    if (normalizado.length < 2 || !/^[0-9]+$/.test(normalizado.slice(0, -1))) {
+      return false;
+    }
+    const cuerpo = normalizado.slice(0, -1);
+    let dv = normalizado.slice(-1);
+    const esperado = digitoVerificador(cuerpo);
+    if (dv === '0' && esperado === 'K') {
+      dv = 'K';
+    }
+    return dv === esperado;
+  };
+
+  const actualizarRut = (input) => {
+    const valor = input.value.trim();
+    if (!valor) {
+      input.setCustomValidity('');
+      return;
+    }
+    const formateado = formatearRut(valor);
+    input.value = formateado;
+    if (!rutValido(formateado)) {
+      input.setCustomValidity('El RUT ingresado no es válido.');
+      input.reportValidity();
+    } else {
+      input.setCustomValidity('');
+    }
+  };
+
+  rutInputs.forEach((input) => {
+    input.addEventListener('input', () => {
+      const limpio = limpiarRut(input.value).toUpperCase();
+      input.value = limpio;
+    });
+    input.addEventListener('blur', () => actualizarRut(input));
+    input.addEventListener('change', () => actualizarRut(input));
+    if (input.value) {
+      actualizarRut(input);
+    }
+  });
+
+  if (fechaNacimientoInput) {
+    const actualizarEdad = () => calcularEdad(fechaNacimientoInput.value);
+    fechaNacimientoInput.addEventListener('change', actualizarEdad);
+    fechaNacimientoInput.addEventListener('blur', actualizarEdad);
+    actualizarEdad();
+  }
+
+  if (menorToggle && menorField) {
+    const toggleMenor = () => {
+      const visible = menorToggle.checked;
+      menorField.hidden = !visible;
+      if (!visible) {
+        const campo = menorField.querySelector('input');
+        if (campo) {
+          campo.value = '';
+          campo.setCustomValidity('');
+        }
+      }
+    };
+    menorToggle.addEventListener('change', toggleMenor);
+    toggleMenor();
+  }
+
+  if (consultaSelector && consultaOtro) {
+    const actualizarConsulta = () => {
+      const esOtro = consultaSelector.value === 'Otro';
+      consultaOtro.hidden = !esOtro;
+      const campo = consultaOtro.querySelector('input');
+      if (!esOtro && campo) {
+        campo.value = '';
+      }
+    };
+    consultaSelector.addEventListener('change', actualizarConsulta);
+    actualizarConsulta();
+  }
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -103,6 +103,26 @@ h2 {
   font-weight: 600;
 }
 
+.field-note {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-top: 0.25rem;
+  display: block;
+}
+
+.checkbox-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  flex-direction: row;
+}
+
+.checkbox-inline input {
+  width: 18px;
+  height: 18px;
+}
+
 .field-grid input,
 .field-grid select,
 .field-grid textarea,

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,5 +37,6 @@
         <p>SSMO · Gestión de formularios médicos</p>
       </div>
     </footer>
+    <script src="{{ url_for('static', filename='form.js') }}" defer></script>
   </body>
 </html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -49,11 +49,17 @@
         </label>
         <label>
           <span>RUT paciente</span>
-          <input type="text" name="rut" value="{{ campos.rut }}" placeholder="11111111-1" />
+          <input type="text" name="rut" value="{{ campos.rut }}" placeholder="11.111.111-1" data-rut />
+          <small class="field-note">Si el RUT termina en K, ingrese 0. El sistema lo convertirá automáticamente.</small>
         </label>
-        <label>
-          <span>RUT apoderado</span>
-          <input type="text" name="rut_padre" value="{{ campos.rut_padre }}" placeholder="22222222-2" />
+        <label class="checkbox-inline">
+          <input type="checkbox" id="menor-edad" {% if campos.rut_padre %}checked{% endif %} />
+          <span>Paciente menor de edad</span>
+        </label>
+        <label data-menor-field {% if not campos.rut_padre %}hidden{% endif %}>
+          <span>RUT apoderado/padre</span>
+          <input type="text" name="rut_padre" value="{{ campos.rut_padre }}" placeholder="22.222.222-2" data-rut />
+          <small class="field-note">Si el RUT termina en K, ingrese 0. El sistema lo convertirá automáticamente.</small>
         </label>
         <label>
           <span>Sexo</span>
@@ -70,7 +76,7 @@
         </label>
         <label>
           <span>Edad</span>
-          <input type="number" min="0" name="edad" value="{{ campos.edad }}" />
+          <input type="number" min="0" name="edad" value="{{ campos.edad }}" readonly />
         </label>
         <label>
           <span>Domicilio</span>
@@ -78,7 +84,12 @@
         </label>
         <label>
           <span>Comuna</span>
-          <input type="text" name="comuna" value="{{ campos.comuna }}" />
+          <select name="comuna">
+            <option value="" {% if not campos.comuna %}selected{% endif %}>Seleccione una comuna</option>
+            {% for comuna in comunas %}
+              <option value="{{ comuna }}" {% if campos.comuna == comuna %}selected{% endif %}>{{ comuna }}</option>
+            {% endfor %}
+          </select>
         </label>
         <label>
           <span>Teléfono 1</span>
@@ -114,13 +125,20 @@
             <option value="No" {% if campos.grupo_poblacional == 'No' %}selected{% endif %}>No</option>
           </select>
         </label>
+        {% set consulta_seleccion = campos.tipo_consulta if campos.tipo_consulta in tipos_consulta else ('Otro' if campos.tipo_consulta and campos.tipo_consulta.startswith('Otro') else '') %}
+        {% set consulta_detalle = campos.tipo_consulta_detalle if campos.tipo_consulta_detalle is defined and campos.tipo_consulta_detalle else (campos.tipo_consulta.split('Otro - ', 1)[1] if consulta_seleccion == 'Otro' and ' - ' in campos.tipo_consulta else '') %}
         <label>
           <span>Tipo de consulta</span>
-          <select name="tipo_consulta">
-            <option value="" {% if not campos.tipo_consulta %}selected{% endif %}></option>
-            <option value="Individual" {% if campos.tipo_consulta == 'Individual' %}selected{% endif %}>Individual</option>
-            <option value="Grupal" {% if campos.tipo_consulta == 'Grupal' %}selected{% endif %}>Grupal</option>
+          <select name="tipo_consulta" data-consulta-selector>
+            <option value="" {% if not consulta_seleccion %}selected{% endif %}></option>
+            {% for opcion in tipos_consulta %}
+              <option value="{{ opcion }}" {% if consulta_seleccion == opcion %}selected{% endif %}>{{ opcion }}</option>
+            {% endfor %}
           </select>
+        </label>
+        <label class="wide" data-consulta-otro {% if consulta_seleccion != 'Otro' %}hidden{% endif %}>
+          <span>Detalle del tipo de consulta</span>
+          <input type="text" name="tipo_consulta_otro" value="{{ consulta_detalle }}" placeholder="Especifique el motivo" />
         </label>
         <label>
           <span>¿Requiere terapias específicas?</span>
@@ -180,7 +198,8 @@
         </label>
         <label>
           <span>RUT médico</span>
-          <input type="text" name="rut_medico" value="{{ campos.rut_medico }}" placeholder="33333333-3" />
+          <input type="text" name="rut_medico" value="{{ campos.rut_medico }}" placeholder="33.333.333-3" data-rut />
+          <small class="field-note">Si el RUT termina en K, ingrese 0. El sistema lo convertirá automáticamente.</small>
         </label>
       </div>
     </section>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -11,7 +11,6 @@
       </div>
       <div class="summary-actions">
         <a class="secondary" href="{{ url_for('listar_formularios') }}">Volver al listado</a>
-        <a class="secondary" href="{{ url_for('descargar_pdf', form_id=registro.id) }}">Descargar PDF</a>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- elimina la generación y descarga de PDF, incluyendo la dependencia de reportlab
- añade cálculo automático de edad, normalización/validación de RUT y flujo para pacientes menores de edad
- actualiza selecciones de comuna y tipo de consulta con soporte para detalle "Otro" y agrega la lógica en un nuevo script front-end

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e66abde64c832e92a218d78b05ffb4