### PR TITLE
Keep optional fields disabled until activated

### DIFF
--- a/static/form.js
+++ b/static/form.js
@@ -133,15 +133,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (menorToggle && menorField) {
     const toggleMenor = () => {
-      const visible = menorToggle.checked;
-      menorField.hidden = !visible;
-      if (!visible) {
-        const campo = menorField.querySelector('input');
-        if (campo) {
+      const habilitado = menorToggle.checked;
+      const campo = menorField.querySelector('input');
+      if (campo) {
+        campo.disabled = !habilitado;
+        if (!habilitado) {
           campo.value = '';
           campo.setCustomValidity('');
         }
       }
+      menorField.classList.toggle('field-disabled', !habilitado);
     };
     menorToggle.addEventListener('change', toggleMenor);
     toggleMenor();
@@ -150,11 +151,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (consultaSelector && consultaOtro) {
     const actualizarConsulta = () => {
       const esOtro = consultaSelector.value === 'Otro';
-      consultaOtro.hidden = !esOtro;
       const campo = consultaOtro.querySelector('input');
-      if (!esOtro && campo) {
-        campo.value = '';
+      if (campo) {
+        campo.disabled = !esOtro;
+        if (!esOtro) {
+          campo.value = '';
+          campo.setCustomValidity('');
+        }
       }
+      consultaOtro.classList.toggle('field-disabled', !esOtro);
     };
     consultaSelector.addEventListener('change', actualizarConsulta);
     actualizarConsulta();

--- a/static/styles.css
+++ b/static/styles.css
@@ -140,6 +140,16 @@ h2 {
   resize: vertical;
 }
 
+.field-grid label.field-disabled input {
+  background: var(--secondary);
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
+.field-grid label.field-disabled input::placeholder {
+  color: rgba(107, 114, 128, 0.8);
+}
+
 .field-grid label.wide {
   grid-column: 1 / -1;
 }

--- a/templates/form.html
+++ b/templates/form.html
@@ -50,16 +50,23 @@
         <label>
           <span>RUT paciente</span>
           <input type="text" name="rut" value="{{ campos.rut }}" placeholder="11.111.111-1" data-rut />
-          <small class="field-note">Si el RUT termina en K, ingrese 0. El sistema lo convertirá automáticamente.</small>
+          <small class="field-note">Si el RUT termina en K, ingrese 0.</small>
         </label>
         <label class="checkbox-inline">
           <input type="checkbox" id="menor-edad" {% if campos.rut_padre %}checked{% endif %} />
           <span>Paciente menor de edad</span>
         </label>
-        <label data-menor-field {% if not campos.rut_padre %}hidden{% endif %}>
+        <label data-menor-field class="{% if not campos.rut_padre %}field-disabled{% endif %}">
           <span>RUT apoderado/padre</span>
-          <input type="text" name="rut_padre" value="{{ campos.rut_padre }}" placeholder="22.222.222-2" data-rut />
-          <small class="field-note">Si el RUT termina en K, ingrese 0. El sistema lo convertirá automáticamente.</small>
+          <input
+            type="text"
+            name="rut_padre"
+            value="{{ campos.rut_padre }}"
+            placeholder="22.222.222-2"
+            data-rut
+            {% if not campos.rut_padre %}disabled{% endif %}
+          />
+          <small class="field-note">Si el RUT termina en K, ingrese 0.</small>
         </label>
         <label>
           <span>Sexo</span>
@@ -136,9 +143,15 @@
             {% endfor %}
           </select>
         </label>
-        <label class="wide" data-consulta-otro {% if consulta_seleccion != 'Otro' %}hidden{% endif %}>
+        <label class="wide {% if consulta_seleccion != 'Otro' %}field-disabled{% endif %}" data-consulta-otro>
           <span>Detalle del tipo de consulta</span>
-          <input type="text" name="tipo_consulta_otro" value="{{ consulta_detalle }}" placeholder="Especifique el motivo" />
+          <input
+            type="text"
+            name="tipo_consulta_otro"
+            value="{{ consulta_detalle }}"
+            placeholder="Especifique el motivo"
+            {% if consulta_seleccion != 'Otro' %}disabled{% endif %}
+          />
         </label>
         <label>
           <span>¿Requiere terapias específicas?</span>
@@ -199,7 +212,7 @@
         <label>
           <span>RUT médico</span>
           <input type="text" name="rut_medico" value="{{ campos.rut_medico }}" placeholder="33.333.333-3" data-rut />
-          <small class="field-note">Si el RUT termina en K, ingrese 0. El sistema lo convertirá automáticamente.</small>
+          <small class="field-note">Si el RUT termina en K, ingrese 0.</small>
         </label>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- leave the guardian RUT and "otro" consultation detail inputs visible but disabled until their corresponding options are selected
- update the frontend behavior to toggle the disabled state and reset values when the fields are turned off
- add styling so disabled optional inputs appear visually inactive

## Testing
- FLASK_APP=app.py flask run --host=0.0.0.0 --port=5000

------
https://chatgpt.com/codex/tasks/task_e_68e6752e4668832e8a528089294c4185